### PR TITLE
Automatically correlate post

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bluesky-comments",
   "version": "0.3.0",
   "description": "Embed Bluesky comments on your website",
+  "source": "./src/main.jsx",
   "main": "./dist/bluesky-comments.umd.js",
   "module": "./dist/bluesky-comments.es.js",
   "files": [
@@ -44,9 +45,8 @@
   "homepage": "https://github.com/czue/bluesky-comments#readme",
   "exports": {
     ".": {
-      "import": "./dist/bluesky-comments.es.js",
-      "require": "./dist/bluesky-comments.umd.js",
-      "default": "./dist/bluesky-comments.umd.js"
+      "import": "./src/main.jsx",
+      "require": "./dist/bluesky-comments.umd.js"
     },
     "./style.css": "./dist/bluesky-comments.css"
   },

--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
       "default": "./dist/bluesky-comments.umd.js"
     },
     "./style.css": "./dist/bluesky-comments.css"
-  }
+  },
+  "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "exports": {
     ".": {
       "import": "./dist/bluesky-comments.es.js",
-      "require": "./dist/bluesky-comments.umd.js"
+      "require": "./dist/bluesky-comments.umd.js",
+      "default": "./dist/bluesky-comments.umd.js"
     },
     "./style.css": "./dist/bluesky-comments.css"
   }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -33,4 +33,4 @@ const initBlueskyComments = async (elementId, author) => {
   }
 }
 
-export { initBlueskyComments };
+export default initBlueskyComments;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -16,12 +16,11 @@ const initBlueskyComments = async (elementId, author) => {
 
       if (data.posts && data.posts.length > 0) {
         const post = data.posts[0];
-        const formattedUri = `at://${post.author.did}/app.bsky.feed.post/${post.cid}`;
 
-        console.log('Rendering Bluesky comments for URI:', formattedUri);
+        console.log('Rendering Bluesky comments for URI:', post.uri);
         ReactDOM.createRoot(element).render(
           <React.StrictMode>
-            <CommentSection uri={formattedUri} />
+            <CommentSection uri={post.uri} />
           </React.StrictMode>
         )
       } else {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,29 +2,35 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { CommentSection } from './CommentSection'
 
-// Create a global function to initialize the comments
+// Create a function to initialize the comments
 console.log('Initializing Bluesky comments');
-window.initBlueskyComments = (elementId, uri) => {
+const initBlueskyComments = async (elementId, author) => {
   const element = document.getElementById(elementId)
   if (element) {
-    // Ensure URI is properly formatted
-    let formattedUri = uri;
-    if (!uri.startsWith('at://')) {
-      // If it's a bsky.app URL, convert it
-      if (uri.includes('bsky.app/profile/')) {
-        const match = uri.match(/profile\/([\w.]+)\/post\/([\w]+)/);
-        if (match) {
-          const [, did, postId] = match;
-          formattedUri = `at://${did}/app.bsky.feed.post/${postId}`;
-        }
-      }
-    }
+    const currentUrl = window.location.href;
+    const apiUrl = `https://public.api.bsky.app/xrpc/app.bsky.feed.searchPosts?q=*&url=${encodeURIComponent(currentUrl)}&author=${author}`;
 
-    console.log('Rendering Bluesky comments for URI:', formattedUri);
-    ReactDOM.createRoot(element).render(
-      <React.StrictMode>
-        <CommentSection uri={formattedUri} />
-      </React.StrictMode>
-    )
+    try {
+      const response = await fetch(apiUrl);
+      const data = await response.json();
+
+      if (data.posts && data.posts.length > 0) {
+        const post = data.posts[0];
+        const formattedUri = `at://${post.author.did}/app.bsky.feed.post/${post.cid}`;
+
+        console.log('Rendering Bluesky comments for URI:', formattedUri);
+        ReactDOM.createRoot(element).render(
+          <React.StrictMode>
+            <CommentSection uri={formattedUri} />
+          </React.StrictMode>
+        )
+      } else {
+        console.log('No matching post found');
+      }
+    } catch (error) {
+      console.error('Error fetching post:', error);
+    }
   }
 }
+
+export { initBlueskyComments };


### PR DESCRIPTION
Will clean up tomorrow so the original module just works as it did before; might tuck some of the logic into the component itself.

Requires specifying an global `author` instead of one-off `url`.