### PR TITLE
[breaking change] Swtich to only named exports 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add the following importmap to your page anywhere before you use the library:
 
 ```html
 <script type="module">
-  import BlueskyComments from 'https://unpkg.com/bluesky-comments@0.4.0/dist/bluesky-comments.es.js';
+  import { BlueskyComments } from 'https://unpkg.com/bluesky-comments@0.4.0/dist/bluesky-comments.es.js';
   document.addEventListener('DOMContentLoaded', function() {
     const author = 'you.bsky.social';
     if (author) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import { CommentSection } from './CommentSection'
 import { Filters } from './CommentFilters'
 import type { CommentOptions } from './types'
 
-const BlueskyComments = {
+export const BlueskyComments = {
   init: function(elementId: string, options: CommentOptions) {
     const element = document.getElementById(elementId)
     if (!element) return;
@@ -24,8 +24,6 @@ const BlueskyComments = {
 }
 
 // Support both module exports and window global
-export default BlueskyComments;
-
 // Add to window object for UMD builds
 if (typeof window !== 'undefined') {
   (window as any).BlueskyComments = BlueskyComments;


### PR DESCRIPTION
This requires updating from:

```javascript
import BlueskyComments from 'https://unpkg.com/bluesky-comments@0.4.0/dist/bluesky-comments.es.js';
```

to

```javascript
import { BlueskyComments } from 'https://unpkg.com/bluesky-comments@0.4.0/dist/bluesky-comments.es.js';
```

(Adding {brackets} around `BlueskyComments`)