### PR TITLE
Adjust CommentSection.getAtUri() regex to allow passing DIDs as profile value in HTTP post URIs

### DIFF
--- a/src/CommentSection.tsx
+++ b/src/CommentSection.tsx
@@ -7,7 +7,7 @@ import { Comment } from './Comment';
 
 const getAtUri = (uri: string): string => {
   if (!uri.startsWith('at://') && uri.includes('bsky.app/profile/')) {
-    const match = uri.match(/profile\/([\w.]+)\/post\/([\w]+)/);
+    const match = uri.match(/profile\/([\w:.]+)\/post\/([\w]+)/);
     if (match) {
       const [, did, postId] = match;
       return `at://${did}/app.bsky.feed.post/${postId}`;


### PR DESCRIPTION
Currently you can load the comments for a BlueSky post by passing an HTTP URI using the current profile handle for the profile value (i.e. `https://bsky.app/profile/user.bsky.social/post/12345`) or by simply providing an ATProto link containing the DID for the profile (i.e. `at://did:plc:12345/app.bsky.feed.post/12345`). 

However, it is currently not possible to load the comments using an HTTP URI using the post author's DID. `https://bsky.app/profile/did:plc:12345/post/12345` will cause the component to return an error, even if the URI will still bring you to the same post in the browser than if the DID was replaced with that user's current handle.

The problem is that [the regex for matching the profile handle in the post URI](https://github.com/czue/bluesky-comments/blob/f9fe30ca8b4bc3fafa7376813a582f6e2f202828/src/CommentSection.tsx#L10C40-L10C47) currently only checks for alphanumeric characters and dots. It fails to match DIDs as they always contain colons. By adding a colon to the profile capture group, it can capture DIDs (see [this RegExR link](https://regexr.com/8ct9n) for confirmation that the updated Regex accurately captures DIDs in HTTP post URIs). 

Being able to link to posts this way using a DID (for if you want any BlueSky links to function consistently in case you or any user whose post you're linking decides to change the DNS or handle for their BlueSky user account) would be much easier and more intuitive than having to convert the post URI to an AT URI. 
