### PR TITLE
A11y updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bluesky-comments",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bluesky-comments",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@atproto/api": "^0.13.18",

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -7,7 +7,7 @@ type CommentProps = {
   filters?: Array<(arg: any) => boolean>;
 };
 
-export const Comment = ({ comment, filters }: CommentProps) => {
+export const Comment = ({ comment, filters, dataIndex }: CommentProps) => {
   const author = comment.post.author;
   const avatarClassName = styles.avatar;
 
@@ -16,7 +16,7 @@ export const Comment = ({ comment, filters }: CommentProps) => {
   if (filters && !filters.every((filter) => !filter(comment))) return null;
 
   return (
-    <blockquote className={styles.commentContainer}>
+    <blockquote className={styles.commentContainer} data-index={dataIndex}>
       <div className={styles.commentContent}>
         <a
           className={styles.authorLink}
@@ -45,10 +45,10 @@ export const Comment = ({ comment, filters }: CommentProps) => {
       </div>
       {comment.replies && comment.replies.length > 0 && (
         <div className={styles.repliesContainer}>
-          {comment.replies.sort(sortByLikes).map((reply) => {
+          {comment.replies.sort(sortByLikes).map((reply, index) => {
             if (!AppBskyFeedDefs.isThreadViewPost(reply)) return null;
             return (
-              <Comment key={reply.post.uri} comment={reply} filters={filters} />
+              <Comment key={reply.post.uri} comment={reply} filters={filters}/>
             );
           })}
         </div>
@@ -116,7 +116,7 @@ const Actions = ({ post, author }: { post: AppBskyFeedDefs.PostView }) => (
     <div className={`${styles.actionsRow}, ${styles.replyAction}`}>
       <p className="text-xs">
         <a className="replyLink" href={`https://bsky.app/profile/${author.did}/post/${post.uri.split('/').pop()}`} target="_blank" rel="noreferrer noopener">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M7.354 3.646a.5.5 0 0 1 0 .708L3.707 8H10.5a7.5 7.5 0 0 1 7.5 7.5a.5.5 0 0 1-1 0A6.5 6.5 0 0 0 10.5 9H3.707l3.647 3.646a.5.5 0 0 1-.708.708l-4.5-4.5a.5.5 0 0 1 0-.708l4.5-4.5a.5.5 0 0 1 .708 0"/></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M17.25 4a.75.75 0 0 1 .75.75A7.25 7.25 0 0 1 10.75 12H4.56l3.22 3.22a.75.75 0 1 1-1.06 1.06l-4.5-4.5a.75.75 0 0 1 0-1.06l4.5-4.5a.75.75 0 0 1 1.06 1.06L4.56 10.5h6.19a5.75 5.75 0 0 0 5.75-5.75a.75.75 0 0 1 .75-.75"/></svg>
         <span className={styles.screenReader}>Reply to @{author.handle}</span>
         </a>
       </p>

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -116,8 +116,8 @@ const Actions = ({ post, author }: { post: AppBskyFeedDefs.PostView }) => (
     <div className={`${styles.actionsRow}, ${styles.replyAction}`}>
       <p className="text-xs">
         <a className="replyLink" href={`https://bsky.app/profile/${author.did}/post/${post.uri.split('/').pop()}`} target="_blank" rel="noreferrer noopener">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M17.25 4a.75.75 0 0 1 .75.75A7.25 7.25 0 0 1 10.75 12H4.56l3.22 3.22a.75.75 0 1 1-1.06 1.06l-4.5-4.5a.75.75 0 0 1 0-1.06l4.5-4.5a.75.75 0 0 1 1.06 1.06L4.56 10.5h6.19a5.75 5.75 0 0 0 5.75-5.75a.75.75 0 0 1 .75-.75"/></svg>
-        <span className={styles.screenReader}>Reply to @{author.handle}</span>
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M17.25 4a.75.75 0 0 1 .75.75A7.25 7.25 0 0 1 10.75 12H4.56l3.22 3.22a.75.75 0 1 1-1.06 1.06l-4.5-4.5a.75.75 0 0 1 0-1.06l4.5-4.5a.75.75 0 0 1 1.06 1.06L4.56 10.5h6.19a5.75 5.75 0 0 0 5.75-5.75a.75.75 0 0 1 .75-.75"/></svg>
+          <span className={styles.screenReader}>Reply to @{author.handle}</span>
         </a>
       </p>
     </div>

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -16,7 +16,7 @@ export const Comment = ({ comment, filters }: CommentProps) => {
   if (filters && !filters.every((filter) => !filter(comment))) return null;
 
   return (
-    <div className={styles.commentContainer}>
+    <blockquote className={styles.commentContainer}>
       <div className={styles.commentContent}>
         <a
           className={styles.authorLink}
@@ -27,7 +27,7 @@ export const Comment = ({ comment, filters }: CommentProps) => {
           {author.avatar ? (
             <img
               src={comment.post.author.avatar}
-              alt="avatar"
+              alt={`${author.handle} avatar`}
               className={avatarClassName}
             />
           ) : (
@@ -38,16 +38,10 @@ export const Comment = ({ comment, filters }: CommentProps) => {
             <span className={styles.handle}>@{author.handle}</span>
           </p>
         </a>
-        <a
-          href={`https://bsky.app/profile/${author.did}/post/${comment.post.uri
-            .split('/')
-            .pop()}`}
-          target="_blank"
-          rel="noreferrer noopener"
-        >
           <p>{comment.post.record.text}</p>
-          <Actions post={comment.post} />
-        </a>
+            <div className={styles.commentFooter}>
+              <Actions post={comment.post} author={author} />
+            </div>
       </div>
       {comment.replies && comment.replies.length > 0 && (
         <div className={styles.repliesContainer}>
@@ -59,11 +53,11 @@ export const Comment = ({ comment, filters }: CommentProps) => {
           })}
         </div>
       )}
-    </div>
+    </blockquote>
   );
 };
 
-const Actions = ({ post }: { post: AppBskyFeedDefs.PostView }) => (
+const Actions = ({ post, author }: { post: AppBskyFeedDefs.PostView }) => (
   <div className={styles.actionsContainer}>
     <div className={styles.actionsRow}>
       <svg
@@ -73,6 +67,7 @@ const Actions = ({ post }: { post: AppBskyFeedDefs.PostView }) => (
         viewBox="0 0 24 24"
         strokeWidth="1.5"
         stroke="currentColor"
+        aria-hidden="true"
       >
         <path
           strokeLinecap="round"
@@ -80,7 +75,7 @@ const Actions = ({ post }: { post: AppBskyFeedDefs.PostView }) => (
           d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z"
         />
       </svg>
-      <p className="text-xs">{post.replyCount ?? 0}</p>
+      <p className="text-xs">{post.replyCount ?? 0} <span className={styles.screenReader}>replies</span></p>
     </div>
     <div className={styles.actionsRow}>
       <svg
@@ -90,6 +85,7 @@ const Actions = ({ post }: { post: AppBskyFeedDefs.PostView }) => (
         viewBox="0 0 24 24"
         strokeWidth="1.5"
         stroke="currentColor"
+        aria-hidden="true"
       >
         <path
           strokeLinecap="round"
@@ -97,7 +93,7 @@ const Actions = ({ post }: { post: AppBskyFeedDefs.PostView }) => (
           d="M19.5 12c0-1.232-.046-2.453-.138-3.662a4.006 4.006 0 0 0-3.7-3.7 48.678 48.678 0 0 0-7.324 0 4.006 4.006 0 0 0-3.7 3.7c-.017.22-.032.441-.046.662M19.5 12l3-3m-3 3-3-3m-12 3c0 1.232.046 2.453.138 3.662a4.006 4.006 0 0 0 3.7 3.7 48.656 48.656 0 0 0 7.324 0 4.006 4.006 0 0 0 3.7-3.7c.017-.22.032-.441.046-.662M4.5 12l3 3m-3-3-3 3"
         />
       </svg>
-      <p className="text-xs">{post.repostCount ?? 0}</p>
+      <p className="text-xs">{post.repostCount ?? 0}  <span className={styles.screenReader}>reposts</span></p>
     </div>
     <div className={styles.actionsRow}>
       <svg
@@ -107,6 +103,7 @@ const Actions = ({ post }: { post: AppBskyFeedDefs.PostView }) => (
         viewBox="0 0 24 24"
         strokeWidth="1.5"
         stroke="currentColor"
+        aria-hidden="true"
       >
         <path
           strokeLinecap="round"
@@ -114,10 +111,20 @@ const Actions = ({ post }: { post: AppBskyFeedDefs.PostView }) => (
           d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"
         />
       </svg>
-      <p className="text-xs">{post.likeCount ?? 0}</p>
+      <p className="text-xs">{post.likeCount ?? 0}  <span className={styles.screenReader}>likes</span></p>
+    </div>
+    <div className={`${styles.actionsRow}, ${styles.replyAction}`}>
+      <p className="text-xs">
+        <a className="replyLink" href={`https://bsky.app/profile/${author.did}/post/${post.uri.split('/').pop()}`} target="_blank" rel="noreferrer noopener">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><path fill="currentColor" d="M7.354 3.646a.5.5 0 0 1 0 .708L3.207 8.5l4.147 4.146a.5.5 0 0 1-.708.708l-4.5-4.5a.5.5 0 0 1 0-.708l4.5-4.5a.5.5 0 0 1 .708 0m3 0a.5.5 0 0 1 0 .708L6.707 8H10.5a7.5 7.5 0 0 1 7.5 7.5a.5.5 0 0 1-1 0A6.5 6.5 0 0 0 10.5 9H6.707l3.647 3.646a.5.5 0 0 1-.708.708l-4.5-4.5a.5.5 0 0 1 0-.708l4.5-4.5a.5.5 0 0 1 .708 0"/></svg>
+        <span className={styles.screenReader}>Reply to @{author.handle}</span>
+        </a>
+      </p>
     </div>
   </div>
 );
+
+
 
 const sortByLikes = (a: unknown, b: unknown) => {
   if (

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -116,7 +116,7 @@ const Actions = ({ post, author }: { post: AppBskyFeedDefs.PostView }) => (
     <div className={`${styles.actionsRow}, ${styles.replyAction}`}>
       <p className="text-xs">
         <a className="replyLink" href={`https://bsky.app/profile/${author.did}/post/${post.uri.split('/').pop()}`} target="_blank" rel="noreferrer noopener">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><path fill="currentColor" d="M7.354 3.646a.5.5 0 0 1 0 .708L3.207 8.5l4.147 4.146a.5.5 0 0 1-.708.708l-4.5-4.5a.5.5 0 0 1 0-.708l4.5-4.5a.5.5 0 0 1 .708 0m3 0a.5.5 0 0 1 0 .708L6.707 8H10.5a7.5 7.5 0 0 1 7.5 7.5a.5.5 0 0 1-1 0A6.5 6.5 0 0 0 10.5 9H6.707l3.647 3.646a.5.5 0 0 1-.708.708l-4.5-4.5a.5.5 0 0 1 0-.708l4.5-4.5a.5.5 0 0 1 .708 0"/></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><path fill="currentColor" d="M7.354 3.646a.5.5 0 0 1 0 .708L3.707 8H10.5a7.5 7.5 0 0 1 7.5 7.5a.5.5 0 0 1-1 0A6.5 6.5 0 0 0 10.5 9H3.707l3.647 3.646a.5.5 0 0 1-.708.708l-4.5-4.5a.5.5 0 0 1 0-.708l4.5-4.5a.5.5 0 0 1 .708 0"/></svg>
         <span className={styles.screenReader}>Reply to @{author.handle}</span>
         </a>
       </p>

--- a/src/CommentSection.module.css
+++ b/src/CommentSection.module.css
@@ -151,7 +151,6 @@ a {
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  opacity: 0.6;
 }
 
 .replyAction {

--- a/src/CommentSection.module.css
+++ b/src/CommentSection.module.css
@@ -1,6 +1,16 @@
+a {
+  text-decoration: underline;
+}
+
 .container {
   max-width: 740px;
   margin: 0 auto;
+}
+
+/* small reset*/
+.container * {
+  padding: 0;
+  margin: 0;
 }
 
 .statsBar {
@@ -111,7 +121,6 @@
 }
 
 .container a {
-  text-decoration: none;
   color: inherit;
 }
 
@@ -131,17 +140,33 @@
   margin-top: 0.5rem;
   display: flex;
   width: 100%;
-  max-width: 150px;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
   opacity: 0.6;
 }
 
+.replyAction {
+  flex-basis: 50%;
+}
 
 .actionsRow {
   display: flex;
   align-items: center;
   gap: 0.25rem;
+}
+
+.screenReader {
+	border: 0 !important;
+	clip: rect(1px, 1px, 1px, 1px) !important;
+	-webkit-clip-path: inset(50%) !important;
+	clip-path: inset(50%) !important;
+	height: 1px !important;
+	margin: -1px !important;
+	overflow: hidden !important;
+	padding: 0 !important;
+	position: absolute !important;
+	width: 1px !important;
+	white-space: nowrap !important;
 }
 

--- a/src/CommentSection.module.css
+++ b/src/CommentSection.module.css
@@ -157,6 +157,10 @@ a {
   flex-basis: 70%;
 }
 
+.replyAction svg {
+  vertical-align: bottom;
+}
+
 .actionsRow {
   display: flex;
   align-items: center;

--- a/src/CommentSection.module.css
+++ b/src/CommentSection.module.css
@@ -70,9 +70,17 @@ a {
 }
 
 .container .showMoreButton {
-  margin-top: 0.5rem;
-  font-size: 0.875rem;
-  text-decoration: underline;
+  margin: .5rem auto;
+    font-size: 0.875rem;
+    width: fit-content;
+    padding: .25rem .5rem;
+    display: flex;
+    align-items: center;
+    gap: .2rem;
+    background: none;
+    border: 1px solid;
+    border-color: inherit;
+    border-radius: .2rem;
 }
 
 .container .showMoreButton:hover {

--- a/src/CommentSection.module.css
+++ b/src/CommentSection.module.css
@@ -155,7 +155,7 @@ a {
 }
 
 .replyAction {
-  flex-basis: 50%;
+  flex-basis: 70%;
 }
 
 .actionsRow {


### PR DESCRIPTION
Changes:

* Removed link for entire comment
    * Avatar/name/handle are linked and a "reply to [author]" link (added to Actions
* Wrapped comments in `<blockquote>` to provide some semantic structure
* Added `author.handle` to avatar image to provide more specific alt text
* Added screen reader only text to Actions, to provide a clear label for likes, replies, reposts
* Added `aria-hidden` to SVGs to prevent screen readers from discovering them, as the text label is in the screen reader only text
* Removed opacity on actions - color contrast issue
* Underlined links to ensure users could clearly see available links

Demo of behavior (audio is echo-ey). I'm using tab to start (blue outline) and then arrows (red outline) to navigate through comments. 
https://github.com/user-attachments/assets/68b0a522-3ef9-43b1-a0bd-01af752905fd


Note:
Further todos:

* Ensure load more comments manages focus appropriately
* Maybe turn actions into links that perform the action (like, reply, repost)
* parse links in comments (probably have to regex something for bsky links)